### PR TITLE
feat: added lt-LT language

### DIFF
--- a/development.md
+++ b/development.md
@@ -43,7 +43,7 @@ To set up the project locally for development and testing, please follow these s
     ```
 - **constants** - all constants that are globally used and should not change during usage of app, e.g.: height and width of cell, width of single tile.
 - **context** - folder that consists CalendarProvider and LocaleProvider
-- **locales** - folder that consists files with translations (currently en / pl)
+- **locales** - folder that consists files with translations (currently en / pl / lt)
 - **types** - folder that consists all global types and type guards
 - **utils** - folder that consists all utility functions used within app (e.g. drawing all the grid, data parsers etc.)
 

--- a/readme.md
+++ b/readme.md
@@ -138,13 +138,13 @@ const mockedSchedulerData: SchedulerData = [
 
 ##### Scheduler Config Object
 
-| Property Name                        | Type         | Default | Description                                                                                                                                                            |
-| ------------------------------------ | ------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| zoom                                 | `0` or `1`   | 0       | `0` - display grid divided into weeks `1` - display grid divided into days                                                                                             |
-| filterButtonState                    | `number`     | 0       | `< 0` - hides filter button, `0` - state for when filters were not set, `> 0` - state for when some filters were set (allows to also handle `onClearFilterData` event) |
-| maxRecordsPerPage                    | `number`     | 50      | number of items from `SchedulerData` visible per page                                                                                                                  |
-| lang                                 | `en` or `pl` | en      | scheduler's language                                                                                                                                                   |
-| includeTakenHoursOnWeekendsInDayView | `boolean`    | `false` | show weekends as taken when given resource is longer than a week                                                                                                       |
+| Property Name                        | Type               | Default | Description                                                                                                                                                            |
+| ------------------------------------ | ------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| zoom                                 | `0` or `1`         | 0       | `0` - display grid divided into weeks `1` - display grid divided into days                                                                                             |
+| filterButtonState                    | `number`           | 0       | `< 0` - hides filter button, `0` - state for when filters were not set, `> 0` - state for when some filters were set (allows to also handle `onClearFilterData` event) |
+| maxRecordsPerPage                    | `number`           | 50      | number of items from `SchedulerData` visible per page                                                                                                                  |
+| lang                                 | `en`, `pl` or `lt` | en      | scheduler's language                                                                                                                                                   |
+| includeTakenHoursOnWeekendsInDayView | `boolean`          | `false` | show weekends as taken when given resource is longer than a week                                                                                                       |
 
 ##### Scheduler Data
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
           isLoading={false}
           onTileClick={handleTileClick}
           onFilterData={handleFilterData}
-          config={{ zoom: 0, maxRecordsPerPage: maxRecordsPerPage }}
+          config={{ zoom: 0, maxRecordsPerPage: maxRecordsPerPage, lang: "lt" }}
           onItemClick={(data) => console.log("clicked: ", data)}
         />
       ) : (
@@ -79,6 +79,7 @@ function App() {
             onTileClick={handleTileClick}
             onFilterData={handleFilterData}
             onItemClick={(data) => console.log("clicked: ", data)}
+            config={{ zoom: 0, lang: "en" }}
           />
         </StyledSchedulerFrame>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
           isLoading={false}
           onTileClick={handleTileClick}
           onFilterData={handleFilterData}
-          config={{ zoom: 0, maxRecordsPerPage: maxRecordsPerPage, lang: "lt" }}
+          config={{ zoom: 0, maxRecordsPerPage: maxRecordsPerPage }}
           onItemClick={(data) => console.log("clicked: ", data)}
         />
       ) : (
@@ -79,7 +79,6 @@ function App() {
             onTileClick={handleTileClick}
             onFilterData={handleFilterData}
             onItemClick={(data) => console.log("clicked: ", data)}
-            config={{ zoom: 0, lang: "en" }}
           />
         </StyledSchedulerFrame>
       )}

--- a/src/context/LocaleProvider/LocaleProvider.tsx
+++ b/src/context/LocaleProvider/LocaleProvider.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useContext, useEffect, useState } from "react";
 import dayjs from "dayjs";
-import en from "dayjs/locale/en";
-import pl from "dayjs/locale/pl";
 import { LangCodes } from "@/types/global";
 import { localeContext } from "./localeContext";
 import { locales } from "./locales";
@@ -14,7 +12,7 @@ const LocaleProvider = ({ children, lang }: LocaleProviderProps) => {
     const locale = locales.find((l) => {
       return l.id === localLang;
     });
-    locale?.id === "en" ? dayjs.locale({ ...en }) : dayjs.locale({ ...pl });
+    locale && dayjs.locale(locale?.id);
     return locale || locales[0];
   }, [localLang]);
 

--- a/src/context/LocaleProvider/locales.ts
+++ b/src/context/LocaleProvider/locales.ts
@@ -1,5 +1,7 @@
 import { en } from "@/locales/en";
 import { pl } from "@/locales/pl";
+import { lt } from "@/locales/lt";
+
 import { LocaleType } from "./types";
 
 export const locales: LocaleType[] = [
@@ -14,5 +16,11 @@ export const locales: LocaleType[] = [
     name: "POLISH",
     lang: pl,
     translateCode: "pl-PL"
+  },
+  {
+    id: "lt",
+    name: "LITHUANIAN",
+    lang: lt,
+    translateCode: "lt-LT"
   }
 ];

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -1,5 +1,5 @@
 export const lt = {
-  feelingEmpty: "I feel so empty...",
+  feelingEmpty: "Jaučiuosi toks tuščias...",
   free: "Laisva",
   loadNext: "Kitas",
   loadPrevious: "Ankstesnis",

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -1,0 +1,17 @@
+export const lt = {
+  feelingEmpty: "I feel so empty...",
+  free: "Laisva",
+  loadNext: "Kitas",
+  loadPrevious: "Ankstesnis",
+  over: "virš",
+  taken: "Užimta",
+  topbar: {
+    filters: "Filtras",
+    next: "kitas",
+    prev: "ankstesnis",
+    today: "Šiandien",
+    view: "Rodinys"
+  },
+  search: "ieškoti",
+  week: "savaitė"
+};

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -5,7 +5,7 @@ export type FilterButtonState = -1 | 0 | 1;
 type ZoomLevelTuple = typeof allZoomLevel;
 
 export type ZoomLevel = ZoomLevelTuple[number];
-export type LangCodes = "en" | "pl";
+export type LangCodes = "en" | "pl" | "lt";
 export type Config = {
   zoom: ZoomLevel;
   /**


### PR DESCRIPTION
Added Lithuanian language (lt-LT) support

![image](https://github.com/Bitnoise/react-scheduler/assets/13067633/94623bc0-caef-43f2-bebc-e4685df0a519)

Also changed the way dayjs locale is loaded, to avoid having multiples of if statements when the language list gets bigger