### PR TITLE
Fix/schedule-111: chaotic scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitnoi.se/react-scheduler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -260,7 +260,7 @@ data that is accessible as argument of `onItemClick` callback
 | Property Name | Type | Description |
 | -------- | --------------------- | -------------------------------- |
 | id | `string` | unique row id |
-| label | `string` | row's label, `e.g person's name` |
+| label | `SchedulerRowLabel` | row's label, `e.g person's name, surname, icon` |
 
 ##### Resource Item
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,9 +1,8 @@
-import { ChangeEvent, FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChangeEvent, FC, useCallback, useEffect, useRef, useState } from "react";
 import debounce from "lodash.debounce";
 import { useCalendar } from "@/context/CalendarProvider";
 import { Day, SchedulerData, SchedulerProjectData, TooltipData, ZoomLevel } from "@/types/global";
 import { getTooltipData } from "@/utils/getTooltipData";
-import { getDatesRange } from "@/utils/getDatesRange";
 import { usePagination } from "@/hooks/usePagination";
 import EmptyBox from "../EmptyBox";
 import { Grid, Header, LeftColumn, Tooltip } from "..";
@@ -28,11 +27,9 @@ export const Calendar: FC<CalendarProps> = ({ data, onTileClick, onItemClick, to
   const {
     zoom,
     startDate,
-    date,
     config: { includeTakenHoursOnWeekendsInDayView, showTooltip }
   } = useCalendar();
   const gridRef = useRef<HTMLDivElement>(null);
-  const datesRange = useMemo(() => getDatesRange(date, zoom), [date, zoom]);
   const {
     page,
     projectsPerPerson,
@@ -43,7 +40,7 @@ export const Calendar: FC<CalendarProps> = ({ data, onTileClick, onItemClick, to
     next,
     previous,
     reset
-  } = usePagination(filteredData, datesRange);
+  } = usePagination(filteredData);
   const debouncedHandleMouseOver = useRef(
     debounce(
       (

--- a/src/components/Calendar/Grid/Grid.tsx
+++ b/src/components/Calendar/Grid/Grid.tsx
@@ -1,9 +1,10 @@
 import { forwardRef, useCallback, useEffect, useRef } from "react";
 import { drawGrid } from "@/utils/drawGrid/drawGrid";
-import { boxHeight, canvasWrapperId, leftColumnWidth, screenWidthMultiplier } from "@/constants";
+import { boxHeight, canvasWrapperId, leftColumnWidth, outsideWrapperId } from "@/constants";
 import { Loader, Tiles } from "@/components";
 import { useCalendar } from "@/context/CalendarProvider";
 import { resizeCanvas } from "@/utils/resizeCanvas";
+import { getCanvasWidth } from "@/utils/getCanvasWidth";
 import { GridProps } from "./types";
 import { StyledCanvas, StyledInnerWrapper, StyledSpan, StyledWrapper } from "./styles";
 
@@ -18,7 +19,7 @@ const Grid = forwardRef<HTMLDivElement, GridProps>(function Grid(
 
   const handleResize = useCallback(
     (ctx: CanvasRenderingContext2D) => {
-      const width = window.innerWidth * screenWidthMultiplier;
+      const width = getCanvasWidth();
       const height = rows * boxHeight + 1;
       resizeCanvas(ctx, width, height);
       drawGrid(ctx, zoom, rows, cols, startDate);
@@ -50,8 +51,9 @@ const Grid = forwardRef<HTMLDivElement, GridProps>(function Grid(
 
   useEffect(() => {
     if (!refRight.current) return;
-    const observerRight = new IntersectionObserver((e) =>
-      e[0].isIntersecting ? handleScrollNext() : null
+    const observerRight = new IntersectionObserver(
+      (e) => (e[0].isIntersecting ? handleScrollNext() : null),
+      { root: document.getElementById(outsideWrapperId) }
     );
     observerRight.observe(refRight.current);
 
@@ -62,7 +64,10 @@ const Grid = forwardRef<HTMLDivElement, GridProps>(function Grid(
     if (!refLeft.current) return;
     const observerLeft = new IntersectionObserver(
       (e) => (e[0].isIntersecting ? handleScrollPrev() : null),
-      { rootMargin: `0px 0px 0px -${leftColumnWidth}px` }
+      {
+        root: document.getElementById(outsideWrapperId),
+        rootMargin: `0px 0px 0px -${leftColumnWidth}px`
+      }
     );
     observerLeft.observe(refLeft.current);
 

--- a/src/components/Calendar/Header/Header.tsx
+++ b/src/components/Calendar/Header/Header.tsx
@@ -1,9 +1,16 @@
 import { FC, useCallback, useEffect, useRef } from "react";
-import { headerHeight, screenWidthMultiplier, canvasHeaderWrapperId } from "@/constants";
+import {
+  headerHeight,
+  screenWidthMultiplier,
+  canvasHeaderWrapperId,
+  outsideWrapperId,
+  leftColumnWidth
+} from "@/constants";
 import { useCalendar } from "@/context/CalendarProvider";
 import { useLanguage } from "@/context/LocaleProvider";
 import { drawHeader } from "@/utils/drawHeader/drawHeader";
 import { resizeCanvas } from "@/utils/resizeCanvas";
+import { getCanvasWidth } from "@/utils/getCanvasWidth";
 import { HeaderProps } from "./types";
 import { StyledCanvas, StyledOuterWrapper, StyledWrapper } from "./styles";
 import Topbar from "./Topbar";
@@ -15,7 +22,7 @@ const Header: FC<HeaderProps> = ({ zoom, topBarWidth }) => {
 
   const handleResize = useCallback(
     (ctx: CanvasRenderingContext2D) => {
-      const width = window.innerWidth * screenWidthMultiplier;
+      const width = getCanvasWidth();
       const height = headerHeight + 1;
       resizeCanvas(ctx, width, height);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,5 @@ export const maxHoursPerDay = 8;
 export const topRowTextYPos = headerMonthHeight / 2 + 2;
 export const middleRowTextYPos = headerWeekHeight / 2 + headerMonthHeight + 1;
 export const buttonWeeksJump = 2;
-export const scrollWeeksJump = 4;
 export const minutesInHour = 60;
 export const tileDefaultBgColor = "rgb(114,141,226)";

--- a/src/context/CalendarProvider/CalendarProvider.tsx
+++ b/src/context/CalendarProvider/CalendarProvider.tsx
@@ -11,7 +11,7 @@ import { isAvailableZoom } from "@/types/guards";
 import { getDatesRange, getParsedDatesRange } from "@/utils/getDatesRange";
 import { parseDay } from "@/utils/dates";
 import { getCols, getVisibleCols } from "@/utils/getCols";
-import { buttonWeeksJump, outsideWrapperId } from "@/constants";
+import { buttonWeeksJump, outsideWrapperId, screenWidthMultiplier } from "@/constants";
 import { getCanvasWidth } from "@/utils/getCanvasWidth";
 import { calendarContext } from "./calendarContext";
 import { CalendarProviderProps } from "./types";
@@ -63,11 +63,13 @@ const CalendarProvider = ({
             left: canvasWidth / 3
           });
 
-        case "middle":
+        case "middle": {
+          const leftOffset = canvasWidth / screenWidthMultiplier / 4; // 1/4 of component's width
           return outsideWrapper.current?.scrollTo({
             behavior,
-            left: canvasWidth / 2
+            left: canvasWidth / 2 - leftOffset
           });
+        }
 
         default:
           return outsideWrapper.current?.scrollTo({
@@ -170,7 +172,7 @@ const CalendarProvider = ({
 
     loadMore("middle");
     debounce(() => {
-      moveHorizontalScroll("middle");
+      moveHorizontalScroll("middle", "smooth");
     }, 300)();
   }, [isLoading, loadMore, moveHorizontalScroll]);
 

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SchedulerData } from "@/types/global";
-import { DatesRange } from "@/utils/getDatesRange";
 import { splitToPages } from "@/utils/splitToPages";
 import { projectsOnGrid } from "@/utils/getProjectsOnGrid";
 import { getTotalRowsPerPage } from "@/utils/getTotalRowsPerPage";
@@ -8,7 +7,7 @@ import { useCalendar } from "@/context/CalendarProvider";
 import { outsideWrapperId } from "@/constants";
 import { UsePaginationData } from "./types";
 
-export const usePagination = (data: SchedulerData, datesRange: DatesRange): UsePaginationData => {
+export const usePagination = (data: SchedulerData): UsePaginationData => {
   const { recordsThreshold } = useCalendar();
   const [startIndex, setStartIndex] = useState(0);
   const [pageNum, setPage] = useState(0);
@@ -18,10 +17,7 @@ export const usePagination = (data: SchedulerData, datesRange: DatesRange): UseP
     outsideWrapper.current = document.getElementById(outsideWrapperId);
   }, []);
 
-  const { projectsPerPerson, rowsPerPerson } = useMemo(
-    () => projectsOnGrid(data, datesRange),
-    [data, datesRange]
-  );
+  const { projectsPerPerson, rowsPerPerson } = useMemo(() => projectsOnGrid(data), [data]);
 
   const pages = useMemo(
     () => splitToPages(data, projectsPerPerson, rowsPerPerson, recordsThreshold),

--- a/src/utils/getCanvasWidth.ts
+++ b/src/utils/getCanvasWidth.ts
@@ -1,0 +1,7 @@
+import { outsideWrapperId, leftColumnWidth, screenWidthMultiplier } from "@/constants";
+
+export const getCanvasWidth = () => {
+  const wrapperWidth = document.getElementById(outsideWrapperId)?.clientWidth || 0;
+  const width = (wrapperWidth - leftColumnWidth) * screenWidthMultiplier;
+  return width;
+};

--- a/src/utils/getCols.ts
+++ b/src/utils/getCols.ts
@@ -1,6 +1,18 @@
-import { weekWidth, screenWidthMultiplier, dayWidth } from "@/constants";
+import {
+  weekWidth,
+  dayWidth,
+  outsideWrapperId,
+  leftColumnWidth,
+  screenWidthMultiplier
+} from "@/constants";
 
-export const getCols = (zoom: number) =>
-  zoom === 0
-    ? Math.ceil(window.innerWidth / weekWidth) * screenWidthMultiplier
-    : Math.ceil(window.innerWidth / dayWidth) * screenWidthMultiplier;
+export const getCols = (zoom: number) => {
+  const wrapperWidth = document.getElementById(outsideWrapperId)?.clientWidth || 0;
+  const componentWidth = wrapperWidth - leftColumnWidth;
+  const visibleCols =
+    zoom === 0 ? Math.ceil(componentWidth / weekWidth) : Math.ceil(componentWidth / dayWidth);
+
+  return visibleCols * screenWidthMultiplier;
+};
+
+export const getVisibleCols = (zoom: number) => getCols(zoom) / screenWidthMultiplier;

--- a/src/utils/getDatesRange.ts
+++ b/src/utils/getDatesRange.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { weekWidth, dayWidth } from "@/constants";
+import { getCols } from "./getCols";
 
 export type DatesRange = {
   startDate: dayjs.Dayjs;
@@ -12,16 +12,11 @@ export type ParsedDatesRange = {
 };
 
 export const getDatesRange = (date: dayjs.Dayjs, zoom: number): DatesRange => {
-  const cols =
-    zoom === 0
-      ? Math.ceil(window.innerWidth / weekWidth) * 3
-      : Math.ceil(window.innerWidth / dayWidth) * 3;
+  const colsOffset = getCols(zoom) / 2;
   const startDate =
-    zoom === 0
-      ? date.subtract(cols / 3 + 3, "weeks").set("day", 1)
-      : date.subtract(cols / 3 + 3, "days");
+    zoom === 0 ? date.subtract(colsOffset, "weeks") : date.subtract(colsOffset, "days");
 
-  const endDate = zoom === 0 ? startDate.add(cols, "weeks") : startDate.add(cols, "days");
+  const endDate = zoom === 0 ? date.add(colsOffset, "weeks") : date.add(colsOffset, "days");
 
   return {
     startDate,

--- a/src/utils/getProjectsOnGrid.ts
+++ b/src/utils/getProjectsOnGrid.ts
@@ -1,13 +1,12 @@
 import { SchedulerData, SchedulerProjectData } from "@/types/global";
 import { setProjectsInRows } from "./setProjectsInRows";
-import { DatesRange } from "./getDatesRange";
 
 type ProjectsData = [projectsPerPerson: SchedulerProjectData[][][], rowsPerPerson: number[]];
 
-export const projectsOnGrid = (data: SchedulerData, datesRange: DatesRange) => {
+export const projectsOnGrid = (data: SchedulerData) => {
   const initialProjectsData: ProjectsData = [[], []];
   const [projectsPerPerson, rowsPerPerson] = data.reduce((acc, curr) => {
-    const projectsInRows = setProjectsInRows(curr.data, datesRange);
+    const projectsInRows = setProjectsInRows(curr.data);
     acc[0].push(projectsInRows);
     acc[1].push(Math.max(projectsInRows.length, 1));
     return acc;

--- a/src/utils/setProjectsInRows.ts
+++ b/src/utils/setProjectsInRows.ts
@@ -21,8 +21,8 @@ export const setProjectsInRows = (
             break;
           }
           if (
-            dayjs(project.startDate).isBefore(datesRange.startDate, "day") &&
-            dayjs(project.endDate).isAfter(datesRange.endDate, "day")
+            dayjs(project.startDate).isBefore(row[i].startDate, "day") &&
+            dayjs(project.endDate).isAfter(row[i].endDate, "day")
           ) {
             isColliding = true;
             break;

--- a/src/utils/setProjectsInRows.ts
+++ b/src/utils/setProjectsInRows.ts
@@ -1,11 +1,7 @@
 import dayjs from "dayjs";
 import { SchedulerProjectData } from "@/types/global";
-import { DatesRange } from "./getDatesRange";
 
-export const setProjectsInRows = (
-  projects: SchedulerProjectData[],
-  datesRange: DatesRange
-): SchedulerProjectData[][] => {
+export const setProjectsInRows = (projects: SchedulerProjectData[]): SchedulerProjectData[][] => {
   const rows: SchedulerProjectData[][] = [];
   for (const project of projects) {
     let isAdded = false;


### PR DESCRIPTION
Scroll behavior depends on component width, not viewport width. Thanks to that scheduler can be used in different sizes and still have a good scrolling experience.
Scrolling after data load is not using "smooth" transition.
After data load canvas position stays almost at the same position, making it more intuitive and precise.
Date range is calculated correctly - fix for the overlapping events.
