### PR TITLE
fix: resolves issues with multiple projects on same day without overlap

### DIFF
--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -8,7 +8,7 @@ import { outsideWrapperId } from "@/constants";
 import { UsePaginationData } from "./types";
 
 export const usePagination = (data: SchedulerData): UsePaginationData => {
-  const { recordsThreshold } = useCalendar();
+  const { recordsThreshold, zoom } = useCalendar();
   const [startIndex, setStartIndex] = useState(0);
   const [pageNum, setPage] = useState(0);
   const outsideWrapper = useRef<HTMLElement | null>(null);
@@ -17,7 +17,10 @@ export const usePagination = (data: SchedulerData): UsePaginationData => {
     outsideWrapper.current = document.getElementById(outsideWrapperId);
   }, []);
 
-  const { projectsPerPerson, rowsPerPerson } = useMemo(() => projectsOnGrid(data), [data]);
+  const { projectsPerPerson, rowsPerPerson } = useMemo(
+    () => projectsOnGrid(data, zoom),
+    [data, zoom]
+  );
 
   const pages = useMemo(
     () => splitToPages(data, projectsPerPerson, rowsPerPerson, recordsThreshold),

--- a/src/utils/getProjectsOnGrid.ts
+++ b/src/utils/getProjectsOnGrid.ts
@@ -3,10 +3,10 @@ import { setProjectsInRows } from "./setProjectsInRows";
 
 type ProjectsData = [projectsPerPerson: SchedulerProjectData[][][], rowsPerPerson: number[]];
 
-export const projectsOnGrid = (data: SchedulerData) => {
+export const projectsOnGrid = (data: SchedulerData, zoom: number) => {
   const initialProjectsData: ProjectsData = [[], []];
   const [projectsPerPerson, rowsPerPerson] = data.reduce((acc, curr) => {
-    const projectsInRows = setProjectsInRows(curr.data);
+    const projectsInRows = setProjectsInRows(curr.data, zoom);
     acc[0].push(projectsInRows);
     acc[1].push(Math.max(projectsInRows.length, 1));
     return acc;

--- a/src/utils/setProjectsInRows.ts
+++ b/src/utils/setProjectsInRows.ts
@@ -1,7 +1,11 @@
 import dayjs from "dayjs";
 import { SchedulerProjectData } from "@/types/global";
 
-export const setProjectsInRows = (projects: SchedulerProjectData[]): SchedulerProjectData[][] => {
+export const setProjectsInRows = (
+  projects: SchedulerProjectData[],
+  zoom: number
+): SchedulerProjectData[][] => {
+  const comparisonUnit = zoom === 2 ? null : "day";
   const rows: SchedulerProjectData[][] = [];
   for (const project of projects) {
     let isAdded = false;
@@ -10,8 +14,13 @@ export const setProjectsInRows = (projects: SchedulerProjectData[]): SchedulerPr
         let isColliding = false;
         for (let i = 0; i < row.length; i++) {
           if (
-            dayjs(project.startDate).isBetween(row[i].startDate, row[i].endDate, null, "[]") ||
-            dayjs(project.endDate).isBetween(row[i].startDate, row[i].endDate, null, "[]")
+            dayjs(project.startDate).isBetween(
+              row[i].startDate,
+              row[i].endDate,
+              comparisonUnit,
+              "[]"
+            ) ||
+            dayjs(project.endDate).isBetween(row[i].startDate, row[i].endDate, comparisonUnit, "[]")
           ) {
             isColliding = true;
             break;


### PR DESCRIPTION
If some projects occur on the same day but do not actually overlap within that day, this will prevent them from showing on separate rows for zoom level 1 or zoom level 0, which prevents some projects from showing at all unless at zoom 2. This affects any applications that tend to assign "projects" in blocks of hours rather than days.

To resolve this, the `isBetween` comparison is modified to use "day" as the smallest comparison unit when the zoom is 0-1.