### PR TITLE
feat: allow custom tooltip render method, and provide the project info that is being hovered over

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,12 +69,7 @@ function App() {
           config={{
             zoom: 0,
             maxRecordsPerPage: maxRecordsPerPage,
-            showThemeToggle: true,
-            customTooltip: (_, project) => (
-              <div>
-                {project?.title} | {project?.subtitle}
-              </div>
-            )
+            showThemeToggle: true
           }}
           onItemClick={(data) => console.log("clicked: ", data)}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,16 @@ function App() {
           isLoading={false}
           onTileClick={handleTileClick}
           onFilterData={handleFilterData}
-          config={{ zoom: 0, maxRecordsPerPage: maxRecordsPerPage, showThemeToggle: true }}
+          config={{
+            zoom: 0,
+            maxRecordsPerPage: maxRecordsPerPage,
+            showThemeToggle: true,
+            customTooltip: (_, project) => (
+              <div>
+                {project?.title} | {project?.subtitle}
+              </div>
+            )
+          }}
           onItemClick={(data) => console.log("clicked: ", data)}
         />
       ) : (

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -12,6 +12,7 @@ import { StyledOuterWrapper, StyledInnerWrapper, StyledEmptyBoxWrapper } from ".
 const initialTooltipData: TooltipData = {
   coords: { x: 0, y: 0 },
   resourceIndex: 0,
+  project: undefined,
   disposition: {
     taken: { hours: 0, minutes: 0 },
     free: { hours: 0, minutes: 0 },
@@ -33,7 +34,7 @@ export const Calendar: FC<CalendarProps> = ({
   const {
     zoom,
     startDate,
-    config: { includeTakenHoursOnWeekendsInDayView, showTooltip, showThemeToggle }
+    config: { includeTakenHoursOnWeekendsInDayView, showTooltip, showThemeToggle, customTooltip }
   } = useCalendar();
   const gridRef = useRef<HTMLDivElement>(null);
   const {
@@ -62,7 +63,8 @@ export const Calendar: FC<CalendarProps> = ({
         const {
           coords: { x, y },
           resourceIndex,
-          disposition
+          disposition,
+          project
         } = getTooltipData(
           startDate,
           tooltipCoords,
@@ -71,7 +73,7 @@ export const Calendar: FC<CalendarProps> = ({
           zoom,
           includeTakenHoursOnWeekendsInDayView
         );
-        setTooltipData({ coords: { x, y }, resourceIndex, disposition });
+        setTooltipData({ coords: { x, y }, resourceIndex, disposition, project });
         setIsVisible(true);
       },
       300
@@ -157,7 +159,12 @@ export const Calendar: FC<CalendarProps> = ({
           </StyledEmptyBoxWrapper>
         )}
         {showTooltip && isVisible && tooltipData?.resourceIndex > -1 && (
-          <Tooltip tooltipData={tooltipData} zoom={zoom} />
+          <Tooltip
+            tooltipData={tooltipData}
+            project={tooltipData?.project}
+            zoom={zoom}
+            customTooltip={customTooltip}
+          />
         )}
       </StyledInnerWrapper>
     </StyledOuterWrapper>

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -159,12 +159,7 @@ export const Calendar: FC<CalendarProps> = ({
           </StyledEmptyBoxWrapper>
         )}
         {showTooltip && isVisible && tooltipData?.resourceIndex > -1 && (
-          <Tooltip
-            tooltipData={tooltipData}
-            project={tooltipData?.project}
-            zoom={zoom}
-            customTooltip={customTooltip}
-          />
+          <Tooltip tooltipData={tooltipData} zoom={zoom} customTooltip={customTooltip} />
         )}
       </StyledInnerWrapper>
     </StyledOuterWrapper>

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -28,6 +28,7 @@ const Scheduler = ({
       includeTakenHoursOnWeekendsInDayView: false,
       showTooltip: true,
       translations: undefined,
+      customTooltip: undefined,
       ...config
     }),
     [config]

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,9 +14,9 @@ import {
 } from "./styles";
 import { TooltipProps } from "./types";
 
-const Tooltip: FC<TooltipProps> = ({ tooltipData, project, zoom, customTooltip }) => {
+const Tooltip: FC<TooltipProps> = ({ tooltipData, zoom, customTooltip }) => {
   const { taken, free, over } = useLanguage();
-  const { coords, disposition } = tooltipData;
+  const { coords, disposition, project } = tooltipData;
   const tooltipRef = useRef<HTMLDivElement>(null);
   let width = weekWidth;
   switch (zoom) {
@@ -56,7 +56,7 @@ const Tooltip: FC<TooltipProps> = ({ tooltipData, project, zoom, customTooltip }
     <StyledTooltipWrapper ref={tooltipRef}>
       <StyledTooltipContent>
         {customTooltip ? (
-          customTooltip(tooltipData, project)
+          customTooltip(tooltipData)
         ) : (
           <StyledContentWrapper>
             <StyledInnerWrapper>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import { FC, useLayoutEffect, useRef } from "react";
 import { dayWidth, weekWidth, zoom2ColumnWidth } from "@/constants";
 import { useLanguage } from "@/context/LocaleProvider";
+import { CustomTooltipFunction } from "@/types/global";
 import Icon from "../Icon";
 import {
   StyledContentWrapper,
@@ -14,9 +15,8 @@ import {
 } from "./styles";
 import { TooltipProps } from "./types";
 
-const Tooltip: FC<TooltipProps> = ({ tooltipData, zoom }) => {
+const Tooltip: FC<TooltipProps> = ({ tooltipData, project, zoom, customTooltip }) => {
   const { taken, free, over } = useLanguage();
-
   const { coords, disposition } = tooltipData;
   const tooltipRef = useRef<HTMLDivElement>(null);
   let width = weekWidth;
@@ -51,31 +51,35 @@ const Tooltip: FC<TooltipProps> = ({ tooltipData, zoom }) => {
     tooltipRef.current.style.top = `${coords.y + 8}px`;
 
     // disposition.overtime affects tooltip's width, thus it's needed to recalculate it's coords whenever overtime changes
-  }, [coords.x, width, disposition.overtime, coords.y, zoom]);
+  }, [coords.x, width, disposition.overtime, coords.y, zoom, project]);
 
   return (
     <StyledTooltipWrapper ref={tooltipRef}>
       <StyledTooltipContent>
-        <StyledContentWrapper>
-          <StyledInnerWrapper>
-            <Icon iconName="calendarWarning" height="14" />
-            <StyledTextWrapper>
-              <StyledText>{`${taken}: ${disposition.taken.hours}h ${disposition.taken.minutes}m`}</StyledText>
-              {(disposition.overtime.hours > 0 || disposition.overtime.minutes > 0) && (
-                <>
-                  &nbsp;{"-"}&nbsp;
-                  <StyledOvertimeWarning>{`${disposition.overtime.hours}h ${disposition.overtime.minutes}m ${over}`}</StyledOvertimeWarning>
-                </>
-              )}
-            </StyledTextWrapper>
-          </StyledInnerWrapper>
-          <StyledInnerWrapper>
-            <Icon iconName="calendarFree" height="14" />
-            <StyledTextWrapper>
-              <StyledText>{`${free}: ${disposition.free.hours}h ${disposition.free.minutes}m`}</StyledText>
-            </StyledTextWrapper>
-          </StyledInnerWrapper>
-        </StyledContentWrapper>
+        {customTooltip ? (
+          customTooltip(tooltipData, project)
+        ) : (
+          <StyledContentWrapper>
+            <StyledInnerWrapper>
+              <Icon iconName="calendarWarning" height="14" />
+              <StyledTextWrapper>
+                <StyledText>{`${taken}: ${disposition.taken.hours}h ${disposition.taken.minutes}m`}</StyledText>
+                {(disposition.overtime.hours > 0 || disposition.overtime.minutes > 0) && (
+                  <>
+                    &nbsp;{"-"}&nbsp;
+                    <StyledOvertimeWarning>{`${disposition.overtime.hours}h ${disposition.overtime.minutes}m ${over}`}</StyledOvertimeWarning>
+                  </>
+                )}
+              </StyledTextWrapper>
+            </StyledInnerWrapper>
+            <StyledInnerWrapper>
+              <Icon iconName="calendarFree" height="14" />
+              <StyledTextWrapper>
+                <StyledText>{`${free}: ${disposition.free.hours}h ${disposition.free.minutes}m`}</StyledText>
+              </StyledTextWrapper>
+            </StyledInnerWrapper>
+          </StyledContentWrapper>
+        )}
       </StyledTooltipContent>
       <StyledTooltipBeak />
     </StyledTooltipWrapper>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,6 @@
 import { FC, useLayoutEffect, useRef } from "react";
 import { dayWidth, weekWidth, zoom2ColumnWidth } from "@/constants";
 import { useLanguage } from "@/context/LocaleProvider";
-import { CustomTooltipFunction } from "@/types/global";
 import Icon from "../Icon";
 import {
   StyledContentWrapper,

--- a/src/components/Tooltip/types.ts
+++ b/src/components/Tooltip/types.ts
@@ -1,6 +1,8 @@
-import { TooltipData } from "@/types/global";
+import { CustomTooltipFunction, SchedulerProjectData, TooltipData } from "@/types/global";
 
 export type TooltipProps = {
   tooltipData: TooltipData;
   zoom: number;
+  project?: SchedulerProjectData;
+  customTooltip?: CustomTooltipFunction;
 };

--- a/src/components/Tooltip/types.ts
+++ b/src/components/Tooltip/types.ts
@@ -1,8 +1,7 @@
-import { CustomTooltipFunction, SchedulerProjectData, TooltipData } from "@/types/global";
+import { CustomTooltipFunction, TooltipData } from "@/types/global";
 
 export type TooltipProps = {
   tooltipData: TooltipData;
   zoom: number;
-  project?: SchedulerProjectData;
   customTooltip?: CustomTooltipFunction;
 };

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -51,7 +51,13 @@ export type Config = {
    */
   defaultTheme?: "light" | "dark";
   theme?: Theme;
+  customTooltip?: CustomTooltipFunction;
 };
+
+export type CustomTooltipFunction = (
+  tooltipData: TooltipData,
+  project?: SchedulerProjectData
+) => JSX.Element;
 
 export type Theme = {
   light?: Partial<Record<ColorType, string>>;
@@ -192,4 +198,5 @@ export type TooltipData = {
   coords: Coords;
   resourceIndex: number;
   disposition: OccupancyData;
+  project?: SchedulerProjectData;
 };

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -54,10 +54,7 @@ export type Config = {
   customTooltip?: CustomTooltipFunction;
 };
 
-export type CustomTooltipFunction = (
-  tooltipData: TooltipData,
-  project?: SchedulerProjectData
-) => JSX.Element;
+export type CustomTooltipFunction = (tooltipData: TooltipData) => JSX.Element | string;
 
 export type Theme = {
   light?: Partial<Record<ColorType, string>>;

--- a/src/utils/getTooltipData.ts
+++ b/src/utils/getTooltipData.ts
@@ -40,6 +40,8 @@ export const getTooltipData = (
     const sumOfRows = array.slice(0, index + 1).reduce((acc, cur) => acc + cur, 0);
     return sumOfRows >= rowPosition;
   });
+  const rowPositionForPerson =
+    rowPosition - rowsPerPerson.slice(0, resourceIndex).reduce((acc, cur) => acc + cur, 0) - 1;
   const xPos = zoom === 2 ? (column + 1) * currBoxWidth : column * currBoxWidth;
   const yPos = (rowPosition - 1) * boxHeight + boxHeight;
 
@@ -50,7 +52,7 @@ export const getTooltipData = (
     zoom,
     includeTakenHoursOnWeekendsInDayView
   );
-  const project = resourcesData[resourceIndex].flat(2).find((item) => {
+  const project = resourcesData[resourceIndex][rowPositionForPerson].find((item) => {
     if (zoom === 1) {
       return dayjs(focusedDate).isBetween(item.startDate, item.endDate, "day", "[]");
     } else if (zoom === 2) {

--- a/src/utils/getTooltipData.ts
+++ b/src/utils/getTooltipData.ts
@@ -50,5 +50,21 @@ export const getTooltipData = (
     zoom,
     includeTakenHoursOnWeekendsInDayView
   );
-  return { coords: { x: xPos, y: yPos }, resourceIndex, disposition };
+  const project = resourcesData[resourceIndex].flat(2).find((item) => {
+    if (zoom === 1) {
+      return dayjs(focusedDate).isBetween(item.startDate, item.endDate, "day", "[]");
+    } else if (zoom === 2) {
+      return dayjs(focusedDate).isBetween(item.startDate, item.endDate, "hour", "[]");
+    } else {
+      return (
+        dayjs(item.startDate).isBetween(
+          dayjs(focusedDate),
+          dayjs(focusedDate).add(6, "days"),
+          "day",
+          "[]"
+        ) || dayjs(focusedDate).isBetween(dayjs(item.startDate), dayjs(item.endDate), "day", "[]")
+      );
+    }
+  });
+  return { coords: { x: xPos, y: yPos }, resourceIndex, disposition, project };
 };


### PR DESCRIPTION
The current tooltip only shows general information for the given timeslot. A `customTooltip` option has been added to the config for the `Scheduler`. If a function is passed in, this will be used for generating the tooltip content. It will receive the `tooltipData` as well as the `project` if one is selected and should return a React element or string.