### PR TITLE
fix: prevent overlapping tiles

### DIFF
--- a/src/context/CalendarProvider/CalendarProvider.tsx
+++ b/src/context/CalendarProvider/CalendarProvider.tsx
@@ -6,6 +6,8 @@ import isoWeek from "dayjs/plugin/isoWeek";
 import isBetween from "dayjs/plugin/isBetween";
 import duration from "dayjs/plugin/duration";
 import debounce from "lodash.debounce";
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import { Coords, ZoomLevel, allZoomLevel } from "@/types/global";
 import { isAvailableZoom } from "@/types/guards";
 import { getDatesRange, getParsedDatesRange } from "@/utils/getDatesRange";
@@ -26,6 +28,8 @@ dayjs.extend(dayOfYear);
 dayjs.extend(isoWeek);
 dayjs.extend(isBetween);
 dayjs.extend(duration);
+dayjs.extend(isSameOrBefore);
+dayjs.extend(isSameOrAfter);
 
 type Direction = "back" | "forward" | "middle";
 

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -8,7 +8,7 @@ import { outsideWrapperId } from "@/constants";
 import { UsePaginationData } from "./types";
 
 export const usePagination = (data: SchedulerData): UsePaginationData => {
-  const { recordsThreshold } = useCalendar();
+  const { recordsThreshold, zoom } = useCalendar();
   const [startIndex, setStartIndex] = useState(0);
   const [pageNum, setPage] = useState(0);
   const outsideWrapper = useRef<HTMLElement | null>(null);
@@ -17,7 +17,10 @@ export const usePagination = (data: SchedulerData): UsePaginationData => {
     outsideWrapper.current = document.getElementById(outsideWrapperId);
   }, []);
 
-  const { projectsPerPerson, rowsPerPerson } = useMemo(() => projectsOnGrid(data), [data]);
+  const { projectsPerPerson, rowsPerPerson } = useMemo(
+    () => projectsOnGrid(data, zoom),
+    [data, zoom]
+  );
 
   const pages = useMemo(
     () => splitToPages(data, projectsPerPerson, rowsPerPerson, recordsThreshold),

--- a/src/utils/getProjectsOnGrid.ts
+++ b/src/utils/getProjectsOnGrid.ts
@@ -1,12 +1,12 @@
-import { SchedulerData, SchedulerProjectData } from "@/types/global";
+import { SchedulerData, SchedulerProjectData, ZoomLevel } from "@/types/global";
 import { setProjectsInRows } from "./setProjectsInRows";
 
 type ProjectsData = [projectsPerPerson: SchedulerProjectData[][][], rowsPerPerson: number[]];
 
-export const projectsOnGrid = (data: SchedulerData) => {
+export const projectsOnGrid = (data: SchedulerData, zoomLevel?: ZoomLevel) => {
   const initialProjectsData: ProjectsData = [[], []];
   const [projectsPerPerson, rowsPerPerson] = data.reduce((acc, curr) => {
-    const projectsInRows = setProjectsInRows(curr.data);
+    const projectsInRows = setProjectsInRows(curr.data, zoomLevel);
     acc[0].push(projectsInRows);
     acc[1].push(Math.max(projectsInRows.length, 1));
     return acc;

--- a/src/utils/setProjectsInRows.ts
+++ b/src/utils/setProjectsInRows.ts
@@ -1,6 +1,5 @@
 import dayjs, { OpUnitType } from "dayjs";
-import { SchedulerProjectData } from "@/types/global";
-import type { ZoomLevel } from "@/types/global";
+import { SchedulerProjectData, ZoomLevel } from "@/types/global";
 
 const ZOOM_LEVEL_TO_COMPARISON_UNIT: Partial<Record<ZoomLevel, OpUnitType>> = {
   0: "day",

--- a/src/utils/setProjectsInRows.ts
+++ b/src/utils/setProjectsInRows.ts
@@ -1,7 +1,17 @@
-import dayjs from "dayjs";
+import dayjs, { OpUnitType } from "dayjs";
 import { SchedulerProjectData } from "@/types/global";
+import type { ZoomLevel } from "@/types/global";
 
-export const setProjectsInRows = (projects: SchedulerProjectData[]): SchedulerProjectData[][] => {
+const ZOOM_LEVEL_TO_COMPARISON_UNIT: Partial<Record<ZoomLevel, OpUnitType>> = {
+  0: "day",
+  1: "day",
+  2: undefined
+};
+
+export const setProjectsInRows = (
+  projects: SchedulerProjectData[],
+  zoomLevel?: ZoomLevel
+): SchedulerProjectData[][] => {
   const rows: SchedulerProjectData[][] = [];
   for (const project of projects) {
     let isAdded = false;
@@ -10,15 +20,14 @@ export const setProjectsInRows = (projects: SchedulerProjectData[]): SchedulerPr
         let isColliding = false;
         for (let i = 0; i < row.length; i++) {
           if (
-            dayjs(project.startDate).isBetween(row[i].startDate, row[i].endDate, null, "[]") ||
-            dayjs(project.endDate).isBetween(row[i].startDate, row[i].endDate, null, "[]")
-          ) {
-            isColliding = true;
-            break;
-          }
-          if (
-            dayjs(project.startDate).isBefore(row[i].startDate, "day") &&
-            dayjs(project.endDate).isAfter(row[i].endDate, "day")
+            dayjs(project.startDate).isSameOrBefore(
+              dayjs(row[i].endDate),
+              ZOOM_LEVEL_TO_COMPARISON_UNIT[zoomLevel || 0]
+            ) &&
+            dayjs(project.endDate).isSameOrAfter(
+              dayjs(row[i].startDate),
+              ZOOM_LEVEL_TO_COMPARISON_UNIT[zoomLevel || 0]
+            )
           ) {
             isColliding = true;
             break;


### PR DESCRIPTION
### **User description**
Done:

- fixed and simplified tiles overlap check

For given set of data:
```
[
  {
    id: "1",
    startDate: new Date("2025-04-08T00:00:00.000Z"),
    endDate: new Date("2025-04-16T00:00:00.000Z"),
    occupancy: 3600,
    title: "First Check",
    bgColor: "rgb(254,165,177)"
  },
  {
    id: "2",
    startDate: new Date("2025-04-15T22:00:00.001Z"),
    endDate: new Date("2025-04-15T23:59:59.999Z"),
    occupancy: 3600,
    title: "Second Check",
    bgColor: "rgb(215, 15, 41)"
  },
  {
    id: "3",
    startDate: new Date("2025-04-16T00:00:00.000Z"),
    endDate: new Date("2025-04-26T21:59:59.999Z"),
    occupancy: 3600,
    title: "Third Check",
    bgColor: "rgb(15, 215, 82)"
  }
]
```

Zoom 0: 

BEFORE: 
![Screenshot 2025-04-16 at 14 46 45](https://github.com/user-attachments/assets/c0ab754f-d7b5-492e-be3f-59e688a7079a)

AFTER:
![Screenshot 2025-04-16 at 14 48 02](https://github.com/user-attachments/assets/c26315bd-1b0d-4163-b0ba-52abf2712402)

Zoom 1:

BEFORE:
![Screenshot 2025-04-16 at 14 50 21](https://github.com/user-attachments/assets/5531b8a6-fb99-43d0-883e-1915f7266a13)

AFTER:
![Screenshot 2025-04-16 at 14 49 28](https://github.com/user-attachments/assets/bea69d0a-6bf8-4b07-b74f-d0d3e8791f2f)

Zoom 2:

BEFORE:
![Screenshot 2025-04-16 at 14 50 54](https://github.com/user-attachments/assets/d8e49c36-db04-47fd-8193-1ab73f6ecc9e)


AFTER:
![Screenshot 2025-04-16 at 14 49 53](https://github.com/user-attachments/assets/586e0434-f99a-4c81-badd-892d422e5582)


___

### **PR Type**
- Bug fix
- Enhancement



___

### **Description**
- Use dayjs plugins for accurate date comparisons

- Pass zoom level to grid project calculations

- Update collision check to use same-or-before/after logic

- Refactor projects grid functions for clarity


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CalendarProvider.tsx</strong><dd><code>Add zoom-aware dayjs comparison plugins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/context/CalendarProvider/CalendarProvider.tsx

<li>Add dayjs plugins: isSameOrBefore, isSameOrAfter<br> <li> Extend dayjs with new plugins for comparisons


</details>


  </td>
  <td><a href="https://github.com/Bitnoise/react-scheduler/pull/192/files#diff-0fbc1fca98486463cf3f23c437fc54d78c25b5bddd6e8119f7f335276bb67b8f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usePagination.ts</strong><dd><code>Update pagination hook for zoom level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/usePagination.ts

<li>Destructure zoom parameter from useCalendar<br> <li> Pass zoom to projectsOnGrid in dependency array


</details>


  </td>
  <td><a href="https://github.com/Bitnoise/react-scheduler/pull/192/files#diff-799edb71de973da75a09a7ad14eccad1236091b37d43ad213b0d9823db5f8f73">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getProjectsOnGrid.ts</strong><dd><code>Update projects grid function with zoom parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/getProjectsOnGrid.ts

<li>Modify projectsOnGrid to accept optional zoomLevel<br> <li> Forward zoomLevel to setProjectsInRows call


</details>


  </td>
  <td><a href="https://github.com/Bitnoise/react-scheduler/pull/192/files#diff-1d56fd363412c936f1c64bd14f1752f0f55d31404ab734a1c5dc5f3be2b61736">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setProjectsInRows.ts</strong><dd><code>Refactor collision check with zoom-aware conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/setProjectsInRows.ts

<li>Add ZOOM_LEVEL_TO_COMPARISON_UNIT mapping constant<br> <li> Replace isBetween and isBefore/After with same-or logic<br> <li> Use zoom level for date comparison unit


</details>


  </td>
  <td><a href="https://github.com/Bitnoise/react-scheduler/pull/192/files#diff-36a64490a6f34a2b610022b51d7a746954715d34c9c47277ca77c61a24bb6146">+20/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>